### PR TITLE
Feature/dispatch

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -5,15 +5,15 @@ Client::Client(SOCKET s, const sockaddr_in& addr)
     std::ostringstream oss;
     oss << inet_ntoa(addr.sin_addr) << ":" << ntohs(addr.sin_port);
     client_addr = oss.str();
-    in_buffer.reserve(512);
-    out_buffer.reserve(512);
+    in_buffer.reserve(BUFF_SIZE);
+    out_buffer.reserve(BUFF_SIZE);
 }
 
 Client::Client()
     : socket(INVALID_SOCKET), last_active(0), state(ClientState::Disconnected) {
     client_addr = "";
-    in_buffer.reserve(512);
-	out_buffer.reserve(512);
+    in_buffer.reserve(BUFF_SIZE);
+	out_buffer.reserve(BUFF_SIZE);
 }
 
 Client::~Client() {}
@@ -27,9 +27,8 @@ void Client::setAwaitingRequest() {
     state = ClientState::AwaitingRequest;
     std::cout << "Client [" << client_addr << "] state changed to AwaitingRequest\n";
 }
-void Client::setRequestBuffered(const std::string& data) {
+void Client::setRequestBuffered() {
     last_active = time(nullptr);
-    in_buffer.append(data);
     state = ClientState::RequestBuffered;
     std::cout << "Client [" << client_addr << "] state changed to RequestBuffered\n";
 }
@@ -43,11 +42,16 @@ void Client::setCompleted() {
     state = ClientState::Completed;
     std::cout << "Client [" << client_addr << "] state changed to Completed\n";
 }
-void Client::setAbort() {
-    state = ClientState::Abort;
+void Client::setAborted() {
+    state = ClientState::Aborted;
     std::cout << "Client [" << client_addr << "] state changed to Aborted\n";
 }
 
 bool Client::isIdle(int timeout_sec) const {
-    return (time(nullptr) - last_active > timeout_sec && state == ClientState::AwaitingRequest);
+    return (difftime(time(nullptr), last_active) > timeout_sec && state == ClientState::AwaitingRequest);
+}
+
+void Client::bufferRequest(const std::string& data) {
+	in_buffer.append(data);
+    setRequestBuffered();
 }

--- a/response.h
+++ b/response.h
@@ -31,11 +31,11 @@ public:
         r.headers["Content-Type"] = "text/plain";
         return r;
     }
-    static Response ok(const std::string& body = "") {
+    static Response ok() {
         Response r;
         r.status_code = 200;
         r.status_text = "OK";
-        r.body = body;
+        r.body = "OK";
         r.headers["Content-Type"] = "text/plain";
         return r;
     }

--- a/server.h
+++ b/server.h
@@ -16,7 +16,7 @@
 
 class Server {
 public:
-    Server(const std::string& ip, int port, std::size_t buffer_size = 512);
+    Server(const std::string& ip, int port, std::size_t buffer_size = 1024);
     ~Server();
     void run();
 private:
@@ -24,9 +24,8 @@ private:
     int port_;
 
     SOCKET listenSocket;
-    sockaddr_in serverService_;
     std::map<SOCKET, Client> clients;
-    const std::size_t RECVBUFF_SIZE;
+	const std::size_t BUFF_SIZE; // Max size of the buffer
 	const time_t CLIENT_TIMEOUT = 120; // 2 minutes
 
     bool listen();
@@ -37,7 +36,7 @@ private:
     bool addClient(SOCKET clientSocket, const sockaddr_in& addr);
     void prepareFdSets(fd_set& readfds, fd_set& writefds);
 	bool pollEvents(fd_set& readfds, fd_set& writefds);
-    void processClients(fd_set& readfds, fd_set& writefds);
+    void processClient(Client& client, fd_set& readfds, fd_set& writefds);
     void dispatch(Client& client); // FSM: RequestBuffered ? ResponseReady
 };
 


### PR DESCRIPTION
This pull request refactors the client-server buffer management, improves the finite state machine (FSM) for client state transitions, and enhances the handling of HTTP connections and partial data transfers. The main changes include introducing a configurable buffer size, renaming and cleaning up state management methods, and improving how client events are processed for better reliability and maintainability.

**Buffer Management Improvements**
* Introduced a new `BUFF_SIZE` constant (default 1024) to replace hardcoded buffer sizes throughout the codebase, ensuring consistent and configurable buffer allocation for both input and output buffers in `Client` and `Server` classes. (`client.cpp` [[1]](diffhunk://#diff-37416bd90f6b7e851b4e0c946f5f40c2b35a74e75f14268a0184e2122bfdfd84L8-R16) `client.h` [[2]](diffhunk://#diff-065f5bc202d5a0dbba2e9e5955aef4efe62bacc0c9e9ae4cf516787ba1a66f75L14-R23) `server.cpp` [[3]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65L4-R4) `server.h` [[4]](diffhunk://#diff-0a806054f10cf65fa608e5aa24cf2ba27a880860ecdf9031e5076a973826dcd9L19-R28)
* Updated constructors and buffer reservation logic to use `BUFF_SIZE` instead of `512`. (`client.cpp` [[1]](diffhunk://#diff-37416bd90f6b7e851b4e0c946f5f40c2b35a74e75f14268a0184e2122bfdfd84L8-R16) `client.h` [[2]](diffhunk://#diff-065f5bc202d5a0dbba2e9e5955aef4efe62bacc0c9e9ae4cf516787ba1a66f75L14-R23)

**Client State Machine and Event Handling**
* Refactored client state transitions: renamed `Abort` to `Aborted`, standardized state-changing methods (`setAborted`, `setRequestBuffered`), and improved idle timeout logic for clarity and correctness. (`client.cpp` [[1]](diffhunk://#diff-37416bd90f6b7e851b4e0c946f5f40c2b35a74e75f14268a0184e2122bfdfd84L30-L32) [[2]](diffhunk://#diff-37416bd90f6b7e851b4e0c946f5f40c2b35a74e75f14268a0184e2122bfdfd84L46-R56); `client.h` [[3]](diffhunk://#diff-065f5bc202d5a0dbba2e9e5955aef4efe62bacc0c9e9ae4cf516787ba1a66f75L14-R23) [[4]](diffhunk://#diff-065f5bc202d5a0dbba2e9e5955aef4efe62bacc0c9e9ae4cf516787ba1a66f75L59-R52)
* Added a `keep_alive` flag to the `Client` class to manage persistent connections based on HTTP headers, and updated server logic to handle keep-alive versus close semantics after response transmission. (`client.h` [[1]](diffhunk://#diff-065f5bc202d5a0dbba2e9e5955aef4efe62bacc0c9e9ae4cf516787ba1a66f75R34); `server.cpp` [[2]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65R98-R111) [[3]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65L173-R200)

**Server Event Loop and Client Processing**
* Replaced bulk client event processing with per-client logic in `processClient`, simplifying the main loop and ensuring proper cleanup of completed or aborted clients without iterator invalidation. (`server.cpp` [[1]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65R232-R251) [[2]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65L247-R307); `server.h` [[3]](diffhunk://#diff-0a806054f10cf65fa608e5aa24cf2ba27a880860ecdf9031e5076a973826dcd9L40-R39)
* Improved handling of partial data transfers: input and output buffers now support incremental reads and writes, and the server waits for complete requests before dispatching, as well as for complete response transmission before clearing buffers. (`server.cpp` [[1]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65L124-R171) [[2]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65L173-R200)

**Code Cleanups and Consistency**
* Removed outdated comments and unused code, clarified state transition comments, and standardized naming for buffer sizes and client states. (`client.h` [[1]](diffhunk://#diff-065f5bc202d5a0dbba2e9e5955aef4efe62bacc0c9e9ae4cf516787ba1a66f75L14-R23) [[2]](diffhunk://#diff-065f5bc202d5a0dbba2e9e5955aef4efe62bacc0c9e9ae4cf516787ba1a66f75L59-R52); `server.cpp` [[3]](diffhunk://#diff-a355038590c6bf94c43082b7ba4fac5e986b1f5dfcfb06127c0f9b3e2ac65c65L36)
* Simplified the `Response::ok()` method to always return a plain "OK" body for consistency. (`response.h` [response.hL34-R38](diffhunk://#diff-13680c532e919175a5a0c4f8368e1db6440d60f5f7dd8b5a4bc3415f6b413744L34-R38))